### PR TITLE
Added gamerule to allow players to set the other gamerules locally (per player)

### DIFF
--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/VaultHuntersExtraRules.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/VaultHuntersExtraRules.java
@@ -1,8 +1,11 @@
 package lv.id.bonne.vaulthuntersextrarules;
 
 
+import com.mojang.datafixers.util.Pair;
+import com.mojang.logging.LogUtils;
 import iskallia.vault.world.VaultLoot;
 import lv.id.bonne.vaulthuntersextrarules.command.ExtraRulesCommand;
+import lv.id.bonne.vaulthuntersextrarules.gamerule.Locality;
 import lv.id.bonne.vaulthuntersextrarules.gamerule.VaultExperienceRule;
 import net.minecraft.world.level.GameRules;
 import net.minecraftforge.common.MinecraftForge;
@@ -10,6 +13,7 @@ import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import org.slf4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +26,10 @@ import java.util.Map;
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
 public class VaultHuntersExtraRules
 {
+    public static final Map<String, GameRules.Key<?>> gameRuleIdToKey = new HashMap<>();
+    public static final Map<GameRules.Key<?>, Pair<GameRules.Type<?>, Locality>> extraGameRules = new HashMap<>();
+    private static final Logger LOGGER = LogUtils.getLogger();
+
     /**
      * The main class initialization.
      */
@@ -30,41 +38,46 @@ public class VaultHuntersExtraRules
         MinecraftForge.EVENT_BUS.register(this);
     }
 
-    public static final Map<GameRules.Key<?>, GameRules.Type<?>> localableGameRules = new HashMap<>();
-
-
     /**
      * Initializes custom GameRules.
      *
      * @param event the FMLCommonSetupEvent event
      */
     @SubscribeEvent
-    public static void setupCommon(FMLCommonSetupEvent event)
-    {
+    public static void setupCommon(FMLCommonSetupEvent event) {
         COIN_LOOT = register("vaultExtraCoinDrops",
             GameRules.Category.MISC,
-            VaultLoot.GameRuleValue.create(VaultLoot.NORMAL));
+            VaultLoot.GameRuleValue.create(VaultLoot.NORMAL), Locality.SERVER);
         COPIOUSLY_DROP = register("vaultExtraCopiouslyDropModifier",
             GameRules.Category.MISC,
-            VaultLoot.GameRuleValue.create(VaultLoot.NORMAL));
+            VaultLoot.GameRuleValue.create(VaultLoot.NORMAL), Locality.SERVER);
 
         BONUS_XP = register("vaultExtraBonusExperienceModifier",
             GameRules.Category.MISC,
-            VaultExperienceRule.GameRuleValue.create(VaultExperienceRule.NORMAL));
+            VaultExperienceRule.GameRuleValue.create(VaultExperienceRule.NORMAL), Locality.PLAYER);
         COMPLETION_XP = register("vaultExtraCompletionExperienceModifier",
             GameRules.Category.MISC,
-            VaultExperienceRule.GameRuleValue.create(VaultExperienceRule.NORMAL));
+            VaultExperienceRule.GameRuleValue.create(VaultExperienceRule.NORMAL), Locality.PLAYER);
 
         REUSE_PEDESTALS = register("vaultExtraReusePedestals",
             GameRules.Category.MISC,
-            GameRules.BooleanValue.create(false));
+            GameRules.BooleanValue.create(false), Locality.VAULT);
         SKIP_ALTAR_RETURNING = register("vaultExtraSkipAltarReturning",
             GameRules.Category.MISC,
-            GameRules.BooleanValue.create(false));
+            GameRules.BooleanValue.create(false), Locality.VAULT);
 
         LOCALIZED_GAMERULES = register("vaultExtraLocalizedGameRules",
                 GameRules.Category.MISC,
-                GameRules.BooleanValue.create(false), false);
+                GameRules.BooleanValue.create(false), Locality.SERVER, false);
+    }
+
+    /**
+     * Accessor for fetching the default locality for a gamerule
+     * @param ruleKey Gamerule Key
+     * @return Gamerule's default locality
+     */
+    public static Locality getDefaultLocality(GameRules.Key<?> ruleKey) {
+        return extraGameRules.getOrDefault(ruleKey, new Pair<>(null, Locality.SERVER)).getSecond();
     }
 
     /**
@@ -72,15 +85,17 @@ public class VaultHuntersExtraRules
      * @param name The name of the game rule.
      * @param category The category of the game rule.
      * @param type The type of the game rule.
-     * @param localize Controls whether the GameRule can be controlled independently by different players
+     * @param locality They type of locality the GameRules has
+     * @param hasLocality Controls whether the GameRule has locality
      * @return The game rule key.
      * @param <T> The type of the game rule.
      */
-    public static <T extends GameRules.Value<T>> GameRules.Key<T> register(String name, GameRules.Category category, GameRules.Type<T> type, boolean localize)
+    public static <T extends GameRules.Value<T>> GameRules.Key<T> register(String name, GameRules.Category category, GameRules.Type<T> type, Locality locality, boolean hasLocality)
     {
         GameRules.Key<T> key = GameRules.register(name, category, type);
-        if (localize)
-            localableGameRules.put(key, type);
+        gameRuleIdToKey.put(key.getId(), key);
+        if (hasLocality)
+            extraGameRules.put(key, new Pair<>(type, locality));
         return key;
     }
 
@@ -92,8 +107,8 @@ public class VaultHuntersExtraRules
      * @return The game rule key.
      * @param <T> The type of the game rule.
      */
-    public static <T extends GameRules.Value<T>> GameRules.Key<T> register(String name, GameRules.Category category, GameRules.Type<T> type) {
-        return register(name, category, type, true);
+    public static <T extends GameRules.Value<T>> GameRules.Key<T> register(String name, GameRules.Category category, GameRules.Type<T> type, Locality locality) {
+        return register(name, category, type, locality, true);
     }
 
     /**

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/VaultHuntersExtraRules.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/VaultHuntersExtraRules.java
@@ -2,12 +2,17 @@ package lv.id.bonne.vaulthuntersextrarules;
 
 
 import iskallia.vault.world.VaultLoot;
+import lv.id.bonne.vaulthuntersextrarules.command.ExtraRulesCommand;
 import lv.id.bonne.vaulthuntersextrarules.gamerule.VaultExperienceRule;
 import net.minecraft.world.level.GameRules;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -24,6 +29,8 @@ public class VaultHuntersExtraRules
     {
         MinecraftForge.EVENT_BUS.register(this);
     }
+
+    public static final Map<GameRules.Key<?>, GameRules.Type<?>> localableGameRules = new HashMap<>();
 
 
     /**
@@ -54,8 +61,28 @@ public class VaultHuntersExtraRules
         SKIP_ALTAR_RETURNING = register("vaultExtraSkipAltarReturning",
             GameRules.Category.MISC,
             GameRules.BooleanValue.create(false));
+
+        LOCALIZED_GAMERULES = register("vaultExtraLocalizedGameRules",
+                GameRules.Category.MISC,
+                GameRules.BooleanValue.create(false), false);
     }
 
+    /**
+     * A simple method that initializes game rule.
+     * @param name The name of the game rule.
+     * @param category The category of the game rule.
+     * @param type The type of the game rule.
+     * @param localize Controls whether the GameRule can be controlled independently by different players
+     * @return The game rule key.
+     * @param <T> The type of the game rule.
+     */
+    public static <T extends GameRules.Value<T>> GameRules.Key<T> register(String name, GameRules.Category category, GameRules.Type<T> type, boolean localize)
+    {
+        GameRules.Key<T> key = GameRules.register(name, category, type);
+        if (localize)
+            localableGameRules.put(key, type);
+        return key;
+    }
 
     /**
      * A simple method that initializes game rule.
@@ -65,11 +92,9 @@ public class VaultHuntersExtraRules
      * @return The game rule key.
      * @param <T> The type of the game rule.
      */
-    public static <T extends GameRules.Value<T>> GameRules.Key<T> register(String name, GameRules.Category category, GameRules.Type<T> type)
-    {
-        return GameRules.register(name, category, type);
+    public static <T extends GameRules.Value<T>> GameRules.Key<T> register(String name, GameRules.Category category, GameRules.Type<T> type) {
+        return register(name, category, type, true);
     }
-
 
     /**
      * The Coin Loot GameRule.
@@ -100,4 +125,24 @@ public class VaultHuntersExtraRules
      * The GameRule that allows users to do not return to god altar after completing its challenge.
      */
     public static GameRules.Key<GameRules.BooleanValue> SKIP_ALTAR_RETURNING;
+
+    /**
+     * The GameRule that allows users to have local customization
+     */
+    public static GameRules.Key<GameRules.BooleanValue> LOCALIZED_GAMERULES;
+
+    /**
+     * Forge Event Bus
+     */
+    @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE)
+    public static class ForgeEvents {
+        /**
+         * Registers the mod's commands
+         * @param event The event holding the command dispatcher
+         */
+        @SubscribeEvent
+        public static void registerCommands(RegisterCommandsEvent event) {
+            ExtraRulesCommand.register(event.getDispatcher());
+        }
+    }
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/command/ExtraRulesCommand.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/command/ExtraRulesCommand.java
@@ -1,0 +1,84 @@
+package lv.id.bonne.vaulthuntersextrarules.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.data.WorldSettings;
+import lv.id.bonne.vaulthuntersextrarules.data.storage.PlayerSettings;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.GameRules;
+
+import java.util.Optional;
+
+public class ExtraRulesCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        LiteralArgumentBuilder<CommandSourceStack> baseLiteral = Commands.literal("extra_rules");
+
+        LiteralArgumentBuilder<CommandSourceStack> set = Commands.literal("set");
+
+        VaultHuntersExtraRules.localableGameRules.forEach((key, type) -> {
+            set.then(Commands.literal(key.getId()).executes(ctx -> queryRule(ctx.getSource(), key)
+                    ).then(type.createArgument("value").executes(ctx -> setRule(ctx, key, type))
+                    ).then(Commands.literal("default").executes(ctx -> defaultRule(ctx, key))));
+        });
+
+        dispatcher.register(baseLiteral.then(set));
+    }
+
+    static <T extends GameRules.Value<T>> int setRule(CommandContext<CommandSourceStack> ctx, GameRules.Key<T> ruleKey, GameRules.Type<?> ruleType) throws CommandSyntaxException {
+        CommandSourceStack stack = ctx.getSource();
+
+        WorldSettings settings = WorldSettings.get(stack.getLevel());
+        ServerPlayer player = stack.getPlayerOrException();
+        PlayerSettings playerSettings = settings.getPlayerSettings(player.getUUID());
+
+        Optional<T> tOptional = playerSettings.get(ruleKey);
+        if (tOptional.isPresent()) {
+            tOptional.get().setFromArgument(ctx, "value");
+            stack.sendSuccess(new TranslatableComponent("commands.gamerule.set", ruleKey.getId(), tOptional.get().toString()), true);
+            return tOptional.get().getCommandResult();
+        }
+
+        GameRules.Value<T> value = (GameRules.Value<T>) ruleType.createRule();
+        value.setFromArgument(ctx, "value");
+
+        playerSettings.put(ruleKey, value);
+
+        stack.sendSuccess(new TranslatableComponent("commands.gamerule.set", ruleKey.getId(), value.toString()), true);
+        return value.getCommandResult();
+    }
+
+    static <T extends GameRules.Value<T>> int defaultRule(CommandContext<CommandSourceStack> ctx, GameRules.Key<T> ruleKey) throws CommandSyntaxException {
+        CommandSourceStack stack = ctx.getSource();
+
+        WorldSettings settings = WorldSettings.get(stack.getLevel());
+        ServerPlayer player = stack.getPlayerOrException();
+        PlayerSettings playerSettings = settings.getPlayerSettings(player.getUUID());
+
+        playerSettings.remove(ruleKey);
+
+        stack.sendSuccess(new TranslatableComponent("commands.gamerule.set", ruleKey.getId(), "default"), true);
+        return 0;
+    }
+
+    static <T extends GameRules.Value<T>> int queryRule(CommandSourceStack stack, GameRules.Key<T> ruleKey) throws CommandSyntaxException {
+        WorldSettings settings = WorldSettings.get(stack.getLevel());
+        ServerPlayer player = stack.getPlayerOrException();
+        PlayerSettings playerSettings = settings.getPlayerSettings(player.getUUID());
+
+        Optional<T> tOptional = playerSettings.get(ruleKey);
+        if (tOptional.isPresent()) {
+            stack.sendSuccess(new TranslatableComponent("commands.gamerule.query", ruleKey.getId(), tOptional.get().toString()), false);
+            return tOptional.get().getCommandResult();
+        }
+
+        stack.sendSuccess(new TranslatableComponent("commands.gamerule.query", ruleKey.getId(), "default"), false);
+
+        return 0;
+    }
+}

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/command/ExtraRulesCommand.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/command/ExtraRulesCommand.java
@@ -1,17 +1,21 @@
 package lv.id.bonne.vaulthuntersextrarules.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.data.WorldSettings;
 import lv.id.bonne.vaulthuntersextrarules.data.storage.PlayerSettings;
+import lv.id.bonne.vaulthuntersextrarules.gamerule.Locality;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.GameRules;
+import net.minecraftforge.server.command.EnumArgument;
 
 import java.util.Optional;
 
@@ -21,17 +25,51 @@ public class ExtraRulesCommand {
 
         LiteralArgumentBuilder<CommandSourceStack> set = Commands.literal("set");
 
-        VaultHuntersExtraRules.localableGameRules.forEach((key, type) -> {
+        LiteralArgumentBuilder<CommandSourceStack> local_allowed = Commands.literal("local_allowed").requires(stack -> stack.hasPermission(2));
+
+        VaultHuntersExtraRules.extraGameRules.forEach((key, pair) -> {
+            GameRules.Type<?> type = pair.getFirst();
             set.then(Commands.literal(key.getId()).executes(ctx -> queryRule(ctx.getSource(), key)
                     ).then(type.createArgument("value").executes(ctx -> setRule(ctx, key, type))
                     ).then(Commands.literal("default").executes(ctx -> defaultRule(ctx, key))));
+
+            local_allowed.then(Commands.literal(key.getId()).executes(ctx -> queryAllowed(ctx.getSource(), key)
+                    ).then(Commands.argument("value", EnumArgument.enumArgument(Locality.class)).executes(ctx -> setAllowed(ctx, key))));
         });
 
-        dispatcher.register(baseLiteral.then(set));
+
+
+        dispatcher.register(baseLiteral.then(set).then(local_allowed));
+    }
+
+    private static int setAllowed(CommandContext<CommandSourceStack> ctx, GameRules.Key<?> ruleKey) {
+        CommandSourceStack stack = ctx.getSource();
+        WorldSettings settings = WorldSettings.get(stack.getLevel());
+
+        Locality locality = ctx.getArgument("value", Locality.class);
+
+        settings.setGameRuleLocality(ruleKey, locality);
+
+        stack.sendSuccess(new TranslatableComponent("commands.gamerule.set", ruleKey.getId(), locality), true);
+
+        return 1;
+    }
+
+    private static int queryAllowed(CommandSourceStack stack, GameRules.Key<?> ruleKey) throws CommandSyntaxException {
+        WorldSettings settings = WorldSettings.get(stack.getLevel());
+
+        Locality locality = settings.getGameRuleLocality(ruleKey);
+
+        stack.sendSuccess(new TranslatableComponent("commands.gamerule.query", ruleKey.getId(), locality), false);
+
+        return 1;
     }
 
     static <T extends GameRules.Value<T>> int setRule(CommandContext<CommandSourceStack> ctx, GameRules.Key<T> ruleKey, GameRules.Type<?> ruleType) throws CommandSyntaxException {
         CommandSourceStack stack = ctx.getSource();
+        if (WorldSettings.get(stack.getLevel()).getGameRuleLocality(ruleKey) == Locality.SERVER) {
+            stack.sendFailure(new TextComponent("Per-player configuration is not enabled for this gamerule!"));
+        }
 
         WorldSettings settings = WorldSettings.get(stack.getLevel());
         ServerPlayer player = stack.getPlayerOrException();
@@ -67,6 +105,10 @@ public class ExtraRulesCommand {
     }
 
     static <T extends GameRules.Value<T>> int queryRule(CommandSourceStack stack, GameRules.Key<T> ruleKey) throws CommandSyntaxException {
+        if (WorldSettings.get(stack.getLevel()).getGameRuleLocality(ruleKey) == Locality.SERVER) {
+            stack.sendFailure(new TextComponent("Per-player configuration is not enabled for this gamerule!"));
+        }
+
         WorldSettings settings = WorldSettings.get(stack.getLevel());
         ServerPlayer player = stack.getPlayerOrException();
         PlayerSettings playerSettings = settings.getPlayerSettings(player.getUUID());

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/command/ExtraRulesCommand.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/command/ExtraRulesCommand.java
@@ -1,7 +1,6 @@
 package lv.id.bonne.vaulthuntersextrarules.command;
 
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/data/WorldSettings.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/data/WorldSettings.java
@@ -1,0 +1,98 @@
+package lv.id.bonne.vaulthuntersextrarules.data;
+
+import lv.id.bonne.vaulthuntersextrarules.data.storage.PlayerSettings;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.saveddata.SavedData;
+import net.minecraftforge.fml.util.thread.SidedThreadGroups;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class WorldSettings extends SavedData {
+    private final Map<UUID, PlayerSettings> playerSettings = new HashMap<>();
+    private static final WorldSettings client_settings = WorldSettings.create();
+
+    /**
+     * Creates a WorldSettings instance
+     * @return Default WorldSettings instance
+     */
+    public static WorldSettings create() {
+        return new WorldSettings();
+    }
+
+    /**
+     * Writes our settings onto an NBT tag
+     * @param tag Tag we wish to write our settings onto
+     * @return Modified NBT tag with our settings
+     */
+    @Override
+    public CompoundTag save(CompoundTag tag) {
+        tag.put("playerSettings", serializePlayerSettings());
+
+        return tag;
+    }
+
+    /**
+     * Method for fetching the settings from a Level
+     * @param level Preferably a ServerLevel, but not strictly required.
+     * @return A populated WorldSettings instance
+     */
+    public static WorldSettings get(Level level) {
+        if (Thread.currentThread().getThreadGroup() == SidedThreadGroups.SERVER && level instanceof ServerLevel serverLevel) {
+            return serverLevel.getServer().overworld().getDataStorage().computeIfAbsent(WorldSettings.load(serverLevel), WorldSettings::create, "vault_hunters_extra_rules_WorldSettings");
+        }
+        else {
+            return client_settings; // Should hopefully not be returned 🤞
+        }
+    }
+
+    /**
+     * Generates a function for loading settings from NBT
+     * @param level Preferably the ServerLevel we load our data onto.
+     *              In most cases the overworld since it is always partially loaded.
+     * @return Function for loading settings from NBT
+     */
+    public static Function<CompoundTag, WorldSettings> load(ServerLevel level) {
+        return (tag) -> {
+            WorldSettings data = create();
+
+            // Should only be called once.
+            PlayerSettings.prepare();
+
+            if (tag.contains("playerSettings")) {
+                CompoundTag playersCompound = tag.getCompound("playerSettings");
+                playersCompound.getAllKeys().forEach(playerUUID -> {
+                    data.playerSettings.put(UUID.fromString(playerUUID), new PlayerSettings(playersCompound.getCompound(playerUUID)));
+                });
+            }
+
+            return data;
+        };
+    }
+
+    /**
+     * Creates a NBT tag with UUID-PlayerSettings key-value pairs.
+     * @return A compound tag
+     */
+    public CompoundTag serializePlayerSettings() {
+        CompoundTag tag = new CompoundTag();
+        playerSettings.forEach((key, value) -> {
+            tag.put(key.toString(), value.serialize());
+        });
+        return tag;
+    }
+
+    /**
+     * Accessor method for obtaining a player's settings
+     * Creates a key and value if they don't already exist
+     * @param uuid UUID of the player you would like to access
+     * @return PlayerSettings object
+     */
+    public PlayerSettings getPlayerSettings(UUID uuid) {
+        return this.playerSettings.computeIfAbsent(uuid, uid -> new PlayerSettings());
+    }
+}

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/data/storage/PlayerSettings.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/data/storage/PlayerSettings.java
@@ -1,0 +1,77 @@
+package lv.id.bonne.vaulthuntersextrarules.data.storage;
+
+import lv.id.bonne.vaulthuntersextrarules.mixin.InvokerGameRulesValue;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.GameRules;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class PlayerSettings {
+    private static final Map<String, GameRules.Key<?>> idToKey = new HashMap<>();
+    private static final Map<GameRules.Key<?>, GameRules.Type<?>> keyToType = new HashMap<>();
+    private final Map<GameRules.Key<?>, GameRules.Value<?>> gameRules = new HashMap<>();
+
+    public PlayerSettings() {
+    }
+
+    public PlayerSettings(CompoundTag tag) {
+        this.deserialize(tag);
+    }
+
+    public static void prepare() {
+        idToKey.clear();
+        keyToType.clear();
+
+        GameRules.visitGameRuleTypes(new GameRules.GameRuleTypeVisitor() {
+            @Override
+            public <T extends GameRules.Value<T>> void visit(GameRules.Key<T> key, GameRules.Type<T> type) {
+                idToKey.put(key.getId(), key);
+                keyToType.put(key, type);
+            }
+        });
+    }
+
+    public <T extends GameRules.Value<T>> Optional<T> get(GameRules.Key<T> ruleKey) {
+        if (this.gameRules.containsKey(ruleKey)) {
+            return Optional.of((T)(this.gameRules.get(ruleKey)));
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+
+    @Nullable
+    public <T extends GameRules.Value<T>> T put(GameRules.Key<T> ruleKey, GameRules.Value<T> ruleValue) {
+        return (T) gameRules.put(ruleKey, ruleValue);
+    }
+
+    @Nullable
+    public <T extends GameRules.Value<T>> T remove(GameRules.Key<T> ruleKey) {
+        return (T) gameRules.remove(ruleKey);
+    }
+
+    @Nonnull
+    public CompoundTag serialize() {
+        CompoundTag tag = new CompoundTag();
+        gameRules.forEach((key, value) ->  {
+            tag.putString(key.getId(), value.serialize());
+        });
+        return tag;
+    }
+
+    public void deserialize(CompoundTag tag) {
+        tag.getAllKeys().forEach(gameRuleKeyId -> {
+            if (idToKey.containsKey(gameRuleKeyId)) {
+                GameRules.Key<?> key = idToKey.get(gameRuleKeyId);
+                GameRules.Value<?> value = keyToType.get(key).createRule();
+                ((InvokerGameRulesValue)value).invokeDeserialize(tag.getString(gameRuleKeyId));
+
+                gameRules.put(key, value);
+            }
+        });
+    }
+}

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/gamerule/Locality.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/gamerule/Locality.java
@@ -1,0 +1,7 @@
+package lv.id.bonne.vaulthuntersextrarules.gamerule;
+
+public enum Locality {
+    PLAYER,
+    VAULT,
+    SERVER
+}

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/gamerule/VaultExperienceRule.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/gamerule/VaultExperienceRule.java
@@ -3,15 +3,15 @@ package lv.id.bonne.vaulthuntersextrarules.gamerule;
 
 import com.google.common.collect.ImmutableMap;
 import com.mojang.brigadier.context.CommandContext;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import java.util.Map;
-
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.level.GameRules;
 import net.minecraftforge.server.command.EnumArgument;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
 
 
 /**

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/InvokerGameRulesValue.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/InvokerGameRulesValue.java
@@ -1,0 +1,14 @@
+package lv.id.bonne.vaulthuntersextrarules.mixin;
+
+import net.minecraft.world.level.GameRules;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+/**
+ * Interface for invoking private/protected methods of GameRules.Value
+ */
+@Mixin(GameRules.Value.class)
+public interface InvokerGameRulesValue {
+    @Invoker
+    void invokeDeserialize(String str);
+}

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCoinPilesTileEntity.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCoinPilesTileEntity.java
@@ -7,19 +7,20 @@
 package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-import java.util.List;
-
 import iskallia.vault.block.entity.CoinPilesTileEntity;
 import iskallia.vault.core.data.key.LootTableKey;
 import iskallia.vault.core.event.common.CoinStacksGenerationEvent;
 import iskallia.vault.core.world.loot.generator.LootTableGenerator;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
 import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.List;
 
 
 /**
@@ -39,6 +40,6 @@ public class MixinCoinPilesTileEntity
         LootTableKey key,
         LootTableGenerator generator)
     {
-        generator.itemQuantity = player.getLevel().getGameRules().getRule(VaultHuntersExtraRules.COIN_LOOT).get().getMultiplier() - 1;
+        generator.itemQuantity = GameRuleHelper.getRule(VaultHuntersExtraRules.COIN_LOOT, player.getLevel(), player).get().getMultiplier() - 1;
     }
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCoinPilesTileEntity.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCoinPilesTileEntity.java
@@ -40,6 +40,6 @@ public class MixinCoinPilesTileEntity
         LootTableKey key,
         LootTableGenerator generator)
     {
-        generator.itemQuantity = GameRuleHelper.getRule(VaultHuntersExtraRules.COIN_LOOT, player.getLevel(), player).get().getMultiplier() - 1;
+        generator.itemQuantity = GameRuleHelper.getRule(VaultHuntersExtraRules.COIN_LOOT, player).get().getMultiplier() - 1;
     }
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCrakePedestalObjective.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCrakePedestalObjective.java
@@ -7,18 +7,18 @@
 package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 
+import iskallia.vault.core.event.common.BlockUseEvent;
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.core.vault.objective.CrakePedestalObjective;
+import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
+import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import iskallia.vault.core.event.common.BlockUseEvent;
-import iskallia.vault.core.vault.Vault;
-import iskallia.vault.core.vault.objective.CrakePedestalObjective;
-import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
-import net.minecraft.world.level.Level;
 
 
 /**
@@ -38,6 +38,7 @@ public class MixinCrakePedestalObjective
         at = @At(value = "HEAD"))
     public void injectVariableAssign(Vault vault, BlockUseEvent.Data data, CallbackInfo ci)
     {
+        vault_hunters_extra_rules$vault = vault;
         vault_hunters_extra_rules$world = data.getWorld();
     }
 
@@ -53,9 +54,8 @@ public class MixinCrakePedestalObjective
         index = 1)
     private Comparable<?> addReusePedestal(Comparable<?> par2)
     {
-        return vault_hunters_extra_rules$world == null ||
-            !vault_hunters_extra_rules$world.getGameRules().
-                getRule(VaultHuntersExtraRules.REUSE_PEDESTALS).
+        return vault_hunters_extra_rules$world == null || vault_hunters_extra_rules$vault == null ||
+            !GameRuleHelper.getRule(VaultHuntersExtraRules.REUSE_PEDESTALS, vault_hunters_extra_rules$world, vault_hunters_extra_rules$vault).
                 get();
     }
 
@@ -71,6 +71,7 @@ public class MixinCrakePedestalObjective
     public void injectVariableRemove(Vault vault, BlockUseEvent.Data data, CallbackInfo ci)
     {
         vault_hunters_extra_rules$world = null;
+        vault_hunters_extra_rules$vault = null;
     }
 
 
@@ -79,4 +80,7 @@ public class MixinCrakePedestalObjective
      */
     @Unique
     private static Level vault_hunters_extra_rules$world;
+
+    @Unique
+    private static Vault vault_hunters_extra_rules$vault;
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCrakePedestalObjective.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCrakePedestalObjective.java
@@ -12,6 +12,7 @@ import iskallia.vault.core.vault.Vault;
 import iskallia.vault.core.vault.objective.CrakePedestalObjective;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -38,8 +39,7 @@ public class MixinCrakePedestalObjective
         at = @At(value = "HEAD"))
     public void injectVariableAssign(Vault vault, BlockUseEvent.Data data, CallbackInfo ci)
     {
-        vault_hunters_extra_rules$vault = vault;
-        vault_hunters_extra_rules$world = data.getWorld();
+        vault_hunters_extra_rules$player = data.getPlayer();
     }
 
 
@@ -54,14 +54,14 @@ public class MixinCrakePedestalObjective
         index = 1)
     private Comparable<?> addReusePedestal(Comparable<?> par2)
     {
-        return vault_hunters_extra_rules$world == null || vault_hunters_extra_rules$vault == null ||
-            !GameRuleHelper.getRule(VaultHuntersExtraRules.REUSE_PEDESTALS, vault_hunters_extra_rules$world, vault_hunters_extra_rules$vault).
+        return vault_hunters_extra_rules$player == null ||
+            !GameRuleHelper.getRule(VaultHuntersExtraRules.REUSE_PEDESTALS, vault_hunters_extra_rules$player).
                 get();
     }
 
 
     /**
-     * Removes the vault_hunters_extra_rules$world value.
+     * Removes the vault_hunters_extra_rules$player value.
      * @param vault The vault.
      * @param data The block use event data.
      * @param ci Callback info.
@@ -70,17 +70,13 @@ public class MixinCrakePedestalObjective
         at = @At(value = "RETURN"))
     public void injectVariableRemove(Vault vault, BlockUseEvent.Data data, CallbackInfo ci)
     {
-        vault_hunters_extra_rules$world = null;
-        vault_hunters_extra_rules$vault = null;
+        vault_hunters_extra_rules$player = null;
     }
 
 
     /**
-     * The world variable.
+     * The player variable.
      */
     @Unique
-    private static Level vault_hunters_extra_rules$world;
-
-    @Unique
-    private static Vault vault_hunters_extra_rules$vault;
+    private static Player vault_hunters_extra_rules$player;
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCrakePedestalObjective.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinCrakePedestalObjective.java
@@ -13,7 +13,6 @@ import iskallia.vault.core.vault.objective.CrakePedestalObjective;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinGodAltarTileEntity.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinGodAltarTileEntity.java
@@ -7,18 +7,17 @@
 package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 
+import iskallia.vault.block.base.GodAltarTileEntity;
+import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import iskallia.vault.block.base.GodAltarTileEntity;
-import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.level.Level;
 
 
 /**
@@ -39,6 +38,7 @@ public class MixinGodAltarTileEntity
     public void injectVariableAssign(ServerLevel world, ServerPlayer player, CallbackInfo ci)
     {
         vault_hunters_extra_rules$world = world;
+        vault_hunters_extra_rules$player = player;
     }
 
 
@@ -54,10 +54,10 @@ public class MixinGodAltarTileEntity
     private boolean skipAltarReturning(boolean requiresDraining)
     {
         return requiresDraining &&
-            (vault_hunters_extra_rules$world == null ||
-                !vault_hunters_extra_rules$world.getGameRules().
-                    getRule(VaultHuntersExtraRules.SKIP_ALTAR_RETURNING).
-                    get());
+            (vault_hunters_extra_rules$world == null || vault_hunters_extra_rules$player == null ||
+                !GameRuleHelper.getRule(VaultHuntersExtraRules.SKIP_ALTAR_RETURNING,
+                        vault_hunters_extra_rules$world,
+                        vault_hunters_extra_rules$player).get());
     }
 
 
@@ -72,6 +72,7 @@ public class MixinGodAltarTileEntity
     public void injectVariableRemove(ServerLevel world, ServerPlayer player, CallbackInfo ci)
     {
         vault_hunters_extra_rules$world = null;
+        vault_hunters_extra_rules$player = null;
     }
 
 
@@ -79,5 +80,8 @@ public class MixinGodAltarTileEntity
      * The world variable.
      */
     @Unique
-    private static Level vault_hunters_extra_rules$world;
+    private static ServerLevel vault_hunters_extra_rules$world;
+
+    @Unique
+    private static ServerPlayer vault_hunters_extra_rules$player;
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinGodAltarTileEntity.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinGodAltarTileEntity.java
@@ -37,7 +37,6 @@ public class MixinGodAltarTileEntity
         at = @At(value = "HEAD"))
     public void injectVariableAssign(ServerLevel world, ServerPlayer player, CallbackInfo ci)
     {
-        vault_hunters_extra_rules$world = world;
         vault_hunters_extra_rules$player = player;
     }
 
@@ -54,9 +53,8 @@ public class MixinGodAltarTileEntity
     private boolean skipAltarReturning(boolean requiresDraining)
     {
         return requiresDraining &&
-            (vault_hunters_extra_rules$world == null || vault_hunters_extra_rules$player == null ||
+            (vault_hunters_extra_rules$player == null ||
                 !GameRuleHelper.getRule(VaultHuntersExtraRules.SKIP_ALTAR_RETURNING,
-                        vault_hunters_extra_rules$world,
                         vault_hunters_extra_rules$player).get());
     }
 
@@ -71,7 +69,6 @@ public class MixinGodAltarTileEntity
         at = @At(value = "RETURN"))
     public void injectVariableRemove(ServerLevel world, ServerPlayer player, CallbackInfo ci)
     {
-        vault_hunters_extra_rules$world = null;
         vault_hunters_extra_rules$player = null;
     }
 
@@ -80,8 +77,6 @@ public class MixinGodAltarTileEntity
      * The world variable.
      */
     @Unique
-    private static ServerLevel vault_hunters_extra_rules$world;
-
-    @Unique
     private static ServerPlayer vault_hunters_extra_rules$player;
+
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinLodestoneObjective.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinLodestoneObjective.java
@@ -13,6 +13,7 @@ import iskallia.vault.core.vault.objective.LodestoneObjective;
 import iskallia.vault.core.world.storage.VirtualWorld;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -40,8 +41,7 @@ public class MixinLodestoneObjective
         at = @At(value = "HEAD"))
     public void injectVariableAssign(Vault vault, VirtualWorld world, BlockUseEvent.Data data, CallbackInfo ci)
     {
-        vault_hunters_extra_rules$vault = vault;
-        vault_hunters_extra_rules$world = data.getWorld();
+        vault_hunters_extra_rules$player = data.getPlayer();
     }
 
 
@@ -56,9 +56,9 @@ public class MixinLodestoneObjective
         index = 0)
     private boolean addReuseLodestone(boolean consumed)
     {
-        return vault_hunters_extra_rules$world == null || vault_hunters_extra_rules$vault == null ||
+        return vault_hunters_extra_rules$player == null ||
             !GameRuleHelper.
-                getRule(VaultHuntersExtraRules.REUSE_PEDESTALS, vault_hunters_extra_rules$world, vault_hunters_extra_rules$vault).
+                getRule(VaultHuntersExtraRules.REUSE_PEDESTALS, vault_hunters_extra_rules$player).
                 get();
     }
 
@@ -74,19 +74,12 @@ public class MixinLodestoneObjective
         at = @At(value = "RETURN"))
     public void injectVariableRemove(Vault vault, VirtualWorld world, BlockUseEvent.Data data, CallbackInfo ci)
     {
-        vault_hunters_extra_rules$vault = null;
-        vault_hunters_extra_rules$world = null;
+        vault_hunters_extra_rules$player = null;
     }
 
     /**
-     * The world variable.
+     * The player variable.
      */
     @Unique
-    private static Level vault_hunters_extra_rules$world;
-
-    /**
-     * The vault variable.
-     */
-    @Unique
-    private static Vault vault_hunters_extra_rules$vault;
+    private static Player vault_hunters_extra_rules$player;
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinLodestoneObjective.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinLodestoneObjective.java
@@ -7,19 +7,19 @@
 package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 
+import iskallia.vault.core.event.common.BlockUseEvent;
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.core.vault.objective.LodestoneObjective;
+import iskallia.vault.core.world.storage.VirtualWorld;
+import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
+import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import iskallia.vault.core.event.common.BlockUseEvent;
-import iskallia.vault.core.vault.Vault;
-import iskallia.vault.core.vault.objective.LodestoneObjective;
-import iskallia.vault.core.world.storage.VirtualWorld;
-import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
-import net.minecraft.world.level.Level;
 
 
 /**
@@ -40,6 +40,7 @@ public class MixinLodestoneObjective
         at = @At(value = "HEAD"))
     public void injectVariableAssign(Vault vault, VirtualWorld world, BlockUseEvent.Data data, CallbackInfo ci)
     {
+        vault_hunters_extra_rules$vault = vault;
         vault_hunters_extra_rules$world = data.getWorld();
     }
 
@@ -55,9 +56,9 @@ public class MixinLodestoneObjective
         index = 0)
     private boolean addReuseLodestone(boolean consumed)
     {
-        return vault_hunters_extra_rules$world == null ||
-            !vault_hunters_extra_rules$world.getGameRules().
-                getRule(VaultHuntersExtraRules.REUSE_PEDESTALS).
+        return vault_hunters_extra_rules$world == null || vault_hunters_extra_rules$vault == null ||
+            !GameRuleHelper.
+                getRule(VaultHuntersExtraRules.REUSE_PEDESTALS, vault_hunters_extra_rules$world, vault_hunters_extra_rules$vault).
                 get();
     }
 
@@ -73,6 +74,7 @@ public class MixinLodestoneObjective
         at = @At(value = "RETURN"))
     public void injectVariableRemove(Vault vault, VirtualWorld world, BlockUseEvent.Data data, CallbackInfo ci)
     {
+        vault_hunters_extra_rules$vault = null;
         vault_hunters_extra_rules$world = null;
     }
 
@@ -81,4 +83,10 @@ public class MixinLodestoneObjective
      */
     @Unique
     private static Level vault_hunters_extra_rules$world;
+
+    /**
+     * The vault variable.
+     */
+    @Unique
+    private static Vault vault_hunters_extra_rules$vault;
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinLodestoneObjective.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinLodestoneObjective.java
@@ -14,7 +14,6 @@ import iskallia.vault.core.world.storage.VirtualWorld;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinStatsCollector.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinStatsCollector.java
@@ -7,14 +7,14 @@
 package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 
+import iskallia.vault.core.vault.stat.StatsCollector;
+import iskallia.vault.core.world.storage.VirtualWorld;
+import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import iskallia.vault.core.vault.stat.StatsCollector;
-import iskallia.vault.core.world.storage.VirtualWorld;
-import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 
 
 /**
@@ -37,7 +37,7 @@ public class MixinStatsCollector
         Float m,
         CallbackInfoReturnable<Float> cir)
     {
-        cir.setReturnValue(m * world.getGameRules().getRule(VaultHuntersExtraRules.BONUS_XP).get().getMultiplier());
+        cir.setReturnValue(m * GameRuleHelper.getRule(VaultHuntersExtraRules.BONUS_XP, world).get().getMultiplier());
         cir.cancel();
     }
 
@@ -55,7 +55,7 @@ public class MixinStatsCollector
         Float m,
         CallbackInfoReturnable<Float> cir)
     {
-        cir.setReturnValue(m * world.getGameRules().getRule(VaultHuntersExtraRules.COMPLETION_XP).get().getMultiplier());
+        cir.setReturnValue(m * GameRuleHelper.getRule(VaultHuntersExtraRules.COMPLETION_XP, world).get().getMultiplier());
         cir.cancel();
     }
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinStatsCollector.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinStatsCollector.java
@@ -7,14 +7,26 @@
 package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 
+import iskallia.vault.core.event.common.ListenerJoinEvent;
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.core.vault.stat.StatCollector;
 import iskallia.vault.core.vault.stat.StatsCollector;
 import iskallia.vault.core.world.storage.VirtualWorld;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
+import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import javax.xml.crypto.Data;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 
 /**
@@ -24,23 +36,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(value = StatsCollector.class, remap = false)
 public class MixinStatsCollector
 {
-    /**
-     * Change bonus multiplier to use custom game rule.
-     * @param world The world.
-     * @param m The player multiplier.
-     * @param cir Callback info.
-     */
-    @Inject(method = "lambda$initServer$1",
-        at = @At(value = "HEAD"),
-        cancellable = true)
-    private static void fixBonusMultiplier(VirtualWorld world,
-        Float m,
-        CallbackInfoReturnable<Float> cir)
+    @Inject(method = "lambda$initServer$4",
+            at = @At(value = "HEAD"))
+    private void injectVariableAssign(Vault vault, VirtualWorld world, ListenerJoinEvent.Data data, CallbackInfo ci)
     {
-        cir.setReturnValue(m * GameRuleHelper.getRule(VaultHuntersExtraRules.BONUS_XP, world).get().getMultiplier());
-        cir.cancel();
+        vault_hunters_extra_rules$player = data.getListener().getPlayer().orElse(null);
     }
-
 
     /**
      * Change objective multiplier to use custom game rule.
@@ -55,7 +56,32 @@ public class MixinStatsCollector
         Float m,
         CallbackInfoReturnable<Float> cir)
     {
-        cir.setReturnValue(m * GameRuleHelper.getRule(VaultHuntersExtraRules.COMPLETION_XP, world).get().getMultiplier());
+        cir.setReturnValue(m * GameRuleHelper.getRule(VaultHuntersExtraRules.COMPLETION_XP, vault_hunters_extra_rules$player).get().getMultiplier());
         cir.cancel();
     }
+
+    /**
+     * Change bonus multiplier to use custom game rule.
+     * @param world The world.
+     * @param m The player multiplier.
+     * @param cir Callback info.
+     */
+    @Inject(method = "lambda$initServer$1",
+            at = @At(value = "HEAD"),
+            cancellable = true)
+    private static void fixBonusMultiplier(VirtualWorld world, Float m, CallbackInfoReturnable<Float> cir)
+    {
+        cir.setReturnValue(m * GameRuleHelper.getRule(VaultHuntersExtraRules.BONUS_XP, world, vault_hunters_extra_rules$player).get().getMultiplier());
+        cir.cancel();
+    }
+
+    @Inject(method = "lambda$initServer$4",
+            at = @At(value = "RETURN"))
+    private void injectVariableRemove(Vault vault, VirtualWorld world, ListenerJoinEvent.Data data, CallbackInfo ci)
+    {
+        vault_hunters_extra_rules$player = null;
+    }
+
+    @Unique
+    private static ServerPlayer vault_hunters_extra_rules$player = null;
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinStatsCollector.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinStatsCollector.java
@@ -9,7 +9,6 @@ package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 import iskallia.vault.core.event.common.ListenerJoinEvent;
 import iskallia.vault.core.vault.Vault;
-import iskallia.vault.core.vault.stat.StatCollector;
 import iskallia.vault.core.vault.stat.StatsCollector;
 import iskallia.vault.core.world.storage.VirtualWorld;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
@@ -21,12 +20,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-
-import javax.xml.crypto.Data;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 
 /**

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinVaultBlockOre.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinVaultBlockOre.java
@@ -10,9 +10,11 @@ package lv.id.bonne.vaulthuntersextrarules.mixin;
 import iskallia.vault.block.VaultOreBlock;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -20,6 +22,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -42,9 +45,15 @@ public class MixinVaultBlockOre
         BlockState state,
         LootContext.Builder builder)
     {
+        Player player = null;
+        if (builder.getOptionalParameter(LootContextParams.THIS_ENTITY) instanceof Player entity) {
+            player = entity;
+        }
+
+
         // Get modifier value
         int modifier = GameRuleHelper.
-            getRule(VaultHuntersExtraRules.COPIOUSLY_DROP, builder.getLevel()).get().getMultiplier();
+            getRule(VaultHuntersExtraRules.COPIOUSLY_DROP, builder.getLevel(), player).get().getMultiplier();
 
         // Get starting list of all items.
         List<ItemStack> originalList = new ArrayList<>(originalInstance);

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinVaultBlockOre.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinVaultBlockOre.java
@@ -7,18 +7,19 @@
 package lv.id.bonne.vaulthuntersextrarules.mixin;
 
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import iskallia.vault.block.VaultOreBlock;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.util.GameRuleHelper;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 
 /**
@@ -42,8 +43,8 @@ public class MixinVaultBlockOre
         LootContext.Builder builder)
     {
         // Get modifier value
-        int modifier = builder.getLevel().getGameRules().
-            getRule(VaultHuntersExtraRules.COPIOUSLY_DROP).get().getMultiplier();
+        int modifier = GameRuleHelper.
+            getRule(VaultHuntersExtraRules.COPIOUSLY_DROP, builder.getLevel()).get().getMultiplier();
 
         // Get starting list of all items.
         List<ItemStack> originalList = new ArrayList<>(originalInstance);

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinVaultBlockOre.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/mixin/MixinVaultBlockOre.java
@@ -22,7 +22,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 
 /**

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/util/GameRuleHelper.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/util/GameRuleHelper.java
@@ -6,7 +6,8 @@ import iskallia.vault.world.data.ServerVaults;
 import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
 import lv.id.bonne.vaulthuntersextrarules.data.WorldSettings;
 import lv.id.bonne.vaulthuntersextrarules.data.storage.PlayerSettings;
-import net.minecraft.server.level.ServerPlayer;
+import lv.id.bonne.vaulthuntersextrarules.gamerule.Locality;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 
@@ -17,25 +18,29 @@ import java.util.UUID;
 public class GameRuleHelper {
 
     /**
-     * Helper method to simplify obtaining GameRule values.
-     * Handles localized game rules.
+     * <b>Use {@link GameRuleHelper#getRule(GameRules.Key, Level, Player)} or {@link GameRuleHelper#getRule(GameRules.Key, Player)} instead!</b><br/><br/>
      *
-     * @param ruleKey Key of the GameRule you would like to access
-     * @param anyLevel Any server-side level
+     * Helper method to simplify obtaining GameRule values.<br/>
+     * Handles localized game rules.<br/>
+     *
+     * @param ruleKey    Key of the GameRule you would like to access
+     * @param anyLevel   Any server-side level
      * @param playerUUID The UUID of the player settings we wish to use. If null, reverts to default GameRule handling.
      * @return The GameRule value wrapper
      */
-    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, @Nullable UUID playerUUID) {
+    private static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, @Nullable UUID playerUUID) {
         boolean localizedGameRules = anyLevel.getGameRules().getRule(VaultHuntersExtraRules.LOCALIZED_GAMERULES).get();
 
         if (localizedGameRules && playerUUID != null) {
             WorldSettings settings = WorldSettings.get(anyLevel);
 
-            PlayerSettings ownerSettings = settings.getPlayerSettings(playerUUID);
-            Optional<T> optionalRule = ownerSettings.get(ruleKey);
+            if (settings.getGameRuleLocality(ruleKey) != Locality.SERVER) { // Only if allowed to be local by server owner
+                PlayerSettings ownerSettings = settings.getPlayerSettings(playerUUID);
+                Optional<T> optionalRule = ownerSettings.get(ruleKey);
 
-            if (optionalRule.isPresent()) {
-                return optionalRule.get();
+                if (optionalRule.isPresent()) {
+                    return optionalRule.get();
+                }
             }
         }
 
@@ -43,15 +48,17 @@ public class GameRuleHelper {
     }
 
     /**
-     * Helper method to simplify obtaining GameRule values.
-     * Handles localized game rules.
+     * <b>Use {@link GameRuleHelper#getRule(GameRules.Key, Level, Player)} or {@link GameRuleHelper#getRule(GameRules.Key, Player)} instead!</b><br/><br/>
      *
-     * @param ruleKey Key of the GameRule you would like to access
+     * Helper method to simplify obtaining GameRule values.<br/>
+     * Handles localized game rules.<br/>
+     *
+     * @param ruleKey  Key of the GameRule you would like to access
      * @param anyLevel Any server-side level
-     * @param vault The vault that the player is currently in. If null, reverts to default GameRule handling.
+     * @param vault    The vault that the player is currently in. If null, reverts to default GameRule handling.
      * @return The GameRule value wrapper
      */
-    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, @Nullable Vault vault) {
+    private static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, @Nullable Vault vault) {
         if (vault != null) {
             return getRule(ruleKey, anyLevel, vault.get(Vault.OWNER));
         }
@@ -59,45 +66,70 @@ public class GameRuleHelper {
     }
 
     /**
-     * Helper method to simplify obtaining GameRule values.
-     * Handles localized game rules.
+     * <b>Use {@link GameRuleHelper#getRule(GameRules.Key, Level, Player)} or {@link GameRuleHelper#getRule(GameRules.Key, Player)} instead!</b><br/><br/>
      *
-     * @param ruleKey Key of the GameRule you would like to access
-     * @param anyLevel Any server-side level
+     * Helper method to simplify obtaining GameRule values.<br/>
+     * Handles localized game rules.<br/>
+     *
+     * @param ruleKey    Key of the GameRule you would like to access
+     * @param anyLevel   Any server-side level
      * @param eventLevel The level that the event took place in.
      * @return The GameRule value wrapper
      */
-    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, Level eventLevel) {
+    private static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, Level eventLevel) {
         Optional<Vault> optionalVault = eventLevel.isClientSide ? ClientVaults.getActive() : ServerVaults.get(eventLevel);
 
         return getRule(ruleKey, anyLevel, optionalVault.orElse(null));
     }
 
-    /**
-     * Helper method to simplify obtaining GameRule values.
-     * Handles localized game rules.
-     * <br/><b>NOTE</b>: The UUID of the passed player is <em>NOT</em> used. Rather
-     * the player's level is used to identify the vault.
-     *
-     * @param ruleKey Key of the GameRule you would like to access
-     * @param anyLevel Any server-side level
-     * @param player The player's level is fetched and used as the eventLevel.
-     * @return The GameRule value wrapper
-     */
-    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, ServerPlayer player) {
-        return getRule(ruleKey, anyLevel, player.getLevel());
-    }
 
     /**
-     * Helper method to simplify obtaining GameRule values.
-     * Handles localized game rules.
+     * <b>Use {@link GameRuleHelper#getRule(GameRules.Key, Level, Player)} or {@link GameRuleHelper#getRule(GameRules.Key, Player)} instead!</b><br/><br/>
      *
-     * @param ruleKey Key of the GameRule you would like to access
+     * Helper method to simplify obtaining GameRule values.<br/>
+     * Handles localized game rules.<br/>
+     *
+     * @param ruleKey    Key of the GameRule you would like to access
      * @param eventLevel The level that the event took place in.
      * @return The GameRule value wrapper
      */
-    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level eventLevel) {
+    private static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level eventLevel) {
         return getRule(ruleKey, eventLevel, eventLevel);
     }
 
+    /**
+     * Helper method to simplify obtaining GameRule values.<br/>
+     * Handles localized game rules.<br/>
+     *
+     * @param ruleKey Key of the GameRule you would like to access
+     * @param player  The player who is performing the event
+     * @return The GameRule value wrapper
+     */
+    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Player player) {
+        WorldSettings settings = WorldSettings.get(player.getLevel());
+        return switch (settings.getGameRuleLocality(ruleKey)) {
+            case PLAYER -> getRule(ruleKey, player.getLevel(), player.getUUID());
+            default -> getRule(ruleKey, player.getLevel());
+        };
+
+        //return getRule(ruleKey, player.getLevel());
+    }
+
+    /**
+     * Helper method to simplify obtaining GameRule values.<br/>
+     * Handles localized game rules.<br/>
+     *
+     * @param ruleKey    Key of the GameRule you would like to access
+     * @param eventLevel The level that the event took place in.
+     * @param player     The player who is performing the event
+     * @return The GameRule value wrapper
+     */
+    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level eventLevel, @Nullable Player player) {
+        if (player != null) {
+            return getRule(ruleKey, player);
+        }
+        else {
+            return getRule(ruleKey, eventLevel);
+        }
+    }
 }

--- a/src/main/java/lv/id/bonne/vaulthuntersextrarules/util/GameRuleHelper.java
+++ b/src/main/java/lv/id/bonne/vaulthuntersextrarules/util/GameRuleHelper.java
@@ -1,0 +1,103 @@
+package lv.id.bonne.vaulthuntersextrarules.util;
+
+import iskallia.vault.core.vault.ClientVaults;
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.world.data.ServerVaults;
+import lv.id.bonne.vaulthuntersextrarules.VaultHuntersExtraRules;
+import lv.id.bonne.vaulthuntersextrarules.data.WorldSettings;
+import lv.id.bonne.vaulthuntersextrarules.data.storage.PlayerSettings;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.UUID;
+
+public class GameRuleHelper {
+
+    /**
+     * Helper method to simplify obtaining GameRule values.
+     * Handles localized game rules.
+     *
+     * @param ruleKey Key of the GameRule you would like to access
+     * @param anyLevel Any server-side level
+     * @param playerUUID The UUID of the player settings we wish to use. If null, reverts to default GameRule handling.
+     * @return The GameRule value wrapper
+     */
+    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, @Nullable UUID playerUUID) {
+        boolean localizedGameRules = anyLevel.getGameRules().getRule(VaultHuntersExtraRules.LOCALIZED_GAMERULES).get();
+
+        if (localizedGameRules && playerUUID != null) {
+            WorldSettings settings = WorldSettings.get(anyLevel);
+
+            PlayerSettings ownerSettings = settings.getPlayerSettings(playerUUID);
+            Optional<T> optionalRule = ownerSettings.get(ruleKey);
+
+            if (optionalRule.isPresent()) {
+                return optionalRule.get();
+            }
+        }
+
+        return anyLevel.getGameRules().getRule(ruleKey);
+    }
+
+    /**
+     * Helper method to simplify obtaining GameRule values.
+     * Handles localized game rules.
+     *
+     * @param ruleKey Key of the GameRule you would like to access
+     * @param anyLevel Any server-side level
+     * @param vault The vault that the player is currently in. If null, reverts to default GameRule handling.
+     * @return The GameRule value wrapper
+     */
+    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, @Nullable Vault vault) {
+        if (vault != null) {
+            return getRule(ruleKey, anyLevel, vault.get(Vault.OWNER));
+        }
+        return getRule(ruleKey, anyLevel, (UUID) null);
+    }
+
+    /**
+     * Helper method to simplify obtaining GameRule values.
+     * Handles localized game rules.
+     *
+     * @param ruleKey Key of the GameRule you would like to access
+     * @param anyLevel Any server-side level
+     * @param eventLevel The level that the event took place in.
+     * @return The GameRule value wrapper
+     */
+    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, Level eventLevel) {
+        Optional<Vault> optionalVault = eventLevel.isClientSide ? ClientVaults.getActive() : ServerVaults.get(eventLevel);
+
+        return getRule(ruleKey, anyLevel, optionalVault.orElse(null));
+    }
+
+    /**
+     * Helper method to simplify obtaining GameRule values.
+     * Handles localized game rules.
+     * <br/><b>NOTE</b>: The UUID of the passed player is <em>NOT</em> used. Rather
+     * the player's level is used to identify the vault.
+     *
+     * @param ruleKey Key of the GameRule you would like to access
+     * @param anyLevel Any server-side level
+     * @param player The player's level is fetched and used as the eventLevel.
+     * @return The GameRule value wrapper
+     */
+    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level anyLevel, ServerPlayer player) {
+        return getRule(ruleKey, anyLevel, player.getLevel());
+    }
+
+    /**
+     * Helper method to simplify obtaining GameRule values.
+     * Handles localized game rules.
+     *
+     * @param ruleKey Key of the GameRule you would like to access
+     * @param eventLevel The level that the event took place in.
+     * @return The GameRule value wrapper
+     */
+    public static <T extends GameRules.Value<T>> T getRule(GameRules.Key<T> ruleKey, Level eventLevel) {
+        return getRule(ruleKey, eventLevel, eventLevel);
+    }
+
+}

--- a/src/main/resources/mixins.vault_hunters_extra_rules.vault_hunters.json
+++ b/src/main/resources/mixins.vault_hunters_extra_rules.vault_hunters.json
@@ -4,6 +4,7 @@
   "refmap": "mixins.vault_hunters_extra_rules.refmap.json",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "InvokerGameRulesValue",
     "MixinCoinPilesTileEntity",
     "MixinCrakePedestalObjective",
     "MixinGodAltarTileEntity",


### PR DESCRIPTION
When this gamerule is enabled, the server will prioritize the owner of a vault's chosen options for their gamerules before the value set through gamerules.

To allow players to modify their preferences, I created the `/extra_rules set <gamerule> <value>` command.